### PR TITLE
Added variadic overloads to layout(_:) and sv(_:)

### DIFF
--- a/Stevia/Stevia/Stevia/Source/Stevia+Hierarchy.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Hierarchy.swift
@@ -9,6 +9,10 @@
 import UIKit
 
 public extension UIView {
+    public func sv(subViews:UIView...) -> UIView {
+        return sv(subViews)
+    }
+
     public func sv(subViews:[UIView]) -> UIView {
         for sv in subViews {
             addSubview(sv)

--- a/Stevia/Stevia/Stevia/Source/Stevia+Stacks.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Stacks.swift
@@ -9,7 +9,11 @@
 import Foundation
 
 public extension UIView {
-    
+
+    public func layout(objects:AnyObject...) -> [UIView] {
+        return layout(objects)
+    }
+
     public func layout(objects:[AnyObject]) -> [UIView] {
         return stackV(objects)
     }

--- a/Stevia/Stevia/SteviaTests/HierarchyTests.swift
+++ b/Stevia/Stevia/SteviaTests/HierarchyTests.swift
@@ -34,7 +34,22 @@ class HierarchyTests: XCTestCase {
         XCTAssertFalse(v1.translatesAutoresizingMaskIntoConstraints)
         XCTAssertFalse(v2.translatesAutoresizingMaskIntoConstraints)
     }
-    
+
+    func testVariadicSv() {
+        let view = UIView()
+        let v1 = UIView()
+        let v2 = UIView()
+        view.sv(
+            v1,
+            v2
+            )
+        XCTAssertEqual(view.subviews.count, 2)
+        XCTAssertTrue(view.subviews.contains(v1))
+        XCTAssertTrue(view.subviews.contains(v2))
+        XCTAssertFalse(v1.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertFalse(v2.translatesAutoresizingMaskIntoConstraints)
+    }
+
     func testTableViewCellSV() {
         let cell = UITableViewCell()
         let v1 = UIView()
@@ -42,14 +57,29 @@ class HierarchyTests: XCTestCase {
         cell.sv([
             v1,
             v2
-        ])
+            ])
         XCTAssertEqual(cell.contentView.subviews.count, 2)
         XCTAssertTrue(cell.contentView.subviews.contains(v1))
         XCTAssertTrue(cell.contentView.subviews.contains(v2))
         XCTAssertFalse(v1.translatesAutoresizingMaskIntoConstraints)
         XCTAssertFalse(v2.translatesAutoresizingMaskIntoConstraints)
     }
-    
+
+    func testTableViewCellVariadicSV() {
+        let cell = UITableViewCell()
+        let v1 = UIView()
+        let v2 = UIView()
+        cell.sv(
+            v1,
+            v2
+            )
+        XCTAssertEqual(cell.contentView.subviews.count, 2)
+        XCTAssertTrue(cell.contentView.subviews.contains(v1))
+        XCTAssertTrue(cell.contentView.subviews.contains(v2))
+        XCTAssertFalse(v1.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertFalse(v2.translatesAutoresizingMaskIntoConstraints)
+    }
+
     func testCollectionViewCellSV() {
         let cell = UICollectionViewCell()
         let v1 = UIView()
@@ -58,6 +88,21 @@ class HierarchyTests: XCTestCase {
             v1,
             v2
             ])
+        XCTAssertEqual(cell.contentView.subviews.count, 2)
+        XCTAssertTrue(cell.contentView.subviews.contains(v1))
+        XCTAssertTrue(cell.contentView.subviews.contains(v2))
+        XCTAssertFalse(v1.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertFalse(v2.translatesAutoresizingMaskIntoConstraints)
+    }
+
+    func testCollectionViewCellVariadicSV() {
+        let cell = UICollectionViewCell()
+        let v1 = UIView()
+        let v2 = UIView()
+        cell.sv(
+            v1,
+            v2
+            )
         XCTAssertEqual(cell.contentView.subviews.count, 2)
         XCTAssertTrue(cell.contentView.subviews.contains(v1))
         XCTAssertTrue(cell.contentView.subviews.contains(v2))


### PR DESCRIPTION
Added variadic overloads to layout(_:) and sv(_:) to make array usage optional.