### PR TITLE
Add edge case check for bottom margin layout

### DIFF
--- a/Stevia/Stevia/Stevia/Source/Stevia+Stacks.swift
+++ b/Stevia/Stevia/Stevia/Source/Stevia+Stacks.swift
@@ -45,7 +45,7 @@ public extension UIView {
             case let m as CGFloat:
                 previousMargin = m // Store margin for next pass
                 
-                if i == (objects.count - 1) {
+                if i != 0 && i == (objects.count - 1) {
                     //Last Margin, Bottom
                     if let previousView = objects[i-1] as? UIView {
                         previousView.bottom(m)


### PR DESCRIPTION
If array has only one CGFloat, ( even though this is trivial, it can happen when someone tries to build a array of constraints dynamically), don't do bottom margin constraint logic, as there is no view to apply the margin to.